### PR TITLE
Add Business Analyst Persona Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A team of Agent Personas wrapped in an MCP server that has the ability to levera
 - **Provider/Model Correction**: Automatically correct and validate provider and model names
 - **File Support**: Send prompts from files and save responses to files
 - **Provider/Model Discovery**: List available providers and models
+- **Persona Tools**: Specialized personas like Business Analyst and Team Decision Maker
 
 ## Setup
 
@@ -16,7 +17,7 @@ A team of Agent Personas wrapped in an MCP server that has the ability to levera
 ```bash
 # Clone and install
 git clone https://github.com/danielscholl/agile-team-mcp-server.git
-cd just-prompt
+cd agile-team-mcp-server
 uv sync
 
 # Install
@@ -37,12 +38,18 @@ cp .env.sample .env
 
 Required API keys in your `.env` file:
 ```
+# Required API keys
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-GEMINI_API_KEY=your_gemini_api_key_here
+GOOGLE_API_KEY=your_gemini_api_key_here  # For Gemini models
 GROQ_API_KEY=your_groq_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
 OLLAMA_HOST=http://localhost:11434
+
+# Optional model configuration
+DEFAULT_MODEL=openai:gpt-4o-mini
+DEFAULT_TEAM_MODELS=["openai:gpt-4.1","anthropic:claude-3-7-sonnet","gemini:gemini-2.5-pro"]
+DEFAULT_DECISION_MAKER_MODEL=openai:gpt-4o-mini
 ```
 
 ## MCP Server Configuration
@@ -51,7 +58,7 @@ To utilize this MCP server directly in other projects either use the buttons to 
 
 > Clients tend to have slighty different configurations
 
-[![Install with UV in VS Code](https://img.shields.io/badge/VS_Code-UV-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22just-prompt%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22--from%22%2C%22git%2Bhttps%3A%2F%2Fgithub.com%2Fdanielscholl%2Fagile-team-mcp-server%40main%22%2C%22just-prompt%22%2C%22--default-models%22%2C%22high%2Copenai%3Ao4-mini%3Ahigh%2Canthropic%3Aclaude-3-7-sonnet-20250219%3A4k%2Cgemini%3Agemini-2.5-pro-preview-03-25%2Cgemini%3Agemini-2.5-flash-preview-04-17%22%5D%2C%22env%22%3A%7B%22OPENAI_API_KEY%22%3A%22%24%7Binput%3Aopenai_key%7D%22%2C%22ANTHROPIC_API_KEY%22%3A%22%24%7Binput%3Aanthropic_key%7D%22%2C%22GEMINI_API_KEY%22%3A%22%24%7Binput%3Agemini_key%7D%22%2C%22GROQ_API_KEY%22%3A%22%24%7Binput%3Agroq_key%7D%22%2C%22DEEPSEEK_API_KEY%22%3A%22%24%7Binput%3Adeepseek_key%7D%22%2C%22OLLAMA_HOST%22%3A%22http%3A%2F%2Flocalhost%3A11434%22%7D%2C%22inputs%22%3A%5B%7B%22id%22%3A%22openai_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22OpenAI%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22anthropic_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Anthropic%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22gemini_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Google%20Gemini%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22groq_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Groq%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22deepseek_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22DeepSeek%20API%20Key%22%2C%22password%22%3Atrue%7D%5D%7D)   [![Install with Docker in VS Code](https://img.shields.io/badge/VS_Code-Docker-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22just-prompt%22%2C%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22--mount%22%2C%22type%3Dbind%2Csource%3D%3CYOUR_WORKSPACE_PATH%3E%2Ctarget%3D%2Fworkspace%22%2C%22danielscholl%2Fagile-team-mcp-server%22%5D%2C%22env%22%3A%7B%22OPENAI_API_KEY%22%3A%22%24%7Binput%3Aopenai_key%7D%22%2C%22ANTHROPIC_API_KEY%22%3A%22%24%7Binput%3Aanthropic_key%7D%22%2C%22GEMINI_API_KEY%22%3A%22%24%7Binput%3Agemini_key%7D%22%2C%22GROQ_API_KEY%22%3A%22%24%7Binput%3Agroq_key%7D%22%2C%22DEEPSEEK_API_KEY%22%3A%22%24%7Binput%3Adeepseek_key%7D%22%2C%22OLLAMA_HOST%22%3A%22http%3A%2F%2Flocalhost%3A11434%22%7D%2C%22inputs%22%3A%5B%7B%22id%22%3A%22openai_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22OpenAI%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22anthropic_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Anthropic%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22gemini_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Google%20Gemini%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22groq_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Groq%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22deepseek_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22DeepSeek%20API%20Key%22%2C%22password%22%3Atrue%7D%5D%7D)
+[![Install with UV in VS Code](https://img.shields.io/badge/VS_Code-UV-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22agile-team%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22--from%22%2C%22git%2Bhttps%3A%2F%2Fgithub.com%2Fdanielscholl%2Fagile-team-mcp-server%40main%22%2C%22agile-team%22%5D%2C%22env%22%3A%7B%22OPENAI_API_KEY%22%3A%22%24%7Binput%3Aopenai_key%7D%22%2C%22ANTHROPIC_API_KEY%22%3A%22%24%7Binput%3Aanthropic_key%7D%22%2C%22GOOGLE_API_KEY%22%3A%22%24%7Binput%3Agemini_key%7D%22%2C%22GROQ_API_KEY%22%3A%22%24%7Binput%3Agroq_key%7D%22%2C%22DEEPSEEK_API_KEY%22%3A%22%24%7Binput%3Adeepseek_key%7D%22%2C%22OLLAMA_HOST%22%3A%22http%3A%2F%2Flocalhost%3A11434%22%2C%22DEFAULT_MODEL%22%3A%22openai%3Agpt-4o-mini%22%2C%22DEFAULT_TEAM_MODELS%22%3A%22%5B%5C%22openai%3Agpt-4.1%5C%22%2C%5C%22anthropic%3Aclaude-3-7-sonnet%5C%22%2C%5C%22gemini%3Agemini-2.5-pro%5C%22%5D%22%2C%22DEFAULT_DECISION_MAKER_MODEL%22%3A%22openai%3Agpt-4o-mini%22%7D%2C%22inputs%22%3A%5B%7B%22id%22%3A%22openai_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22OpenAI%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22anthropic_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Anthropic%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22gemini_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Google%20Gemini%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22groq_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Groq%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22deepseek_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22DeepSeek%20API%20Key%22%2C%22password%22%3Atrue%7D%5D%7D)   [![Install with Docker in VS Code](https://img.shields.io/badge/VS_Code-Docker-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22agile-team%22%2C%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22--mount%22%2C%22type%3Dbind%2Csource%3D%3CYOUR_WORKSPACE_PATH%3E%2Ctarget%3D%2Fworkspace%22%2C%22danielscholl%2Fagile-team-mcp-server%22%5D%2C%22env%22%3A%7B%22OPENAI_API_KEY%22%3A%22%24%7Binput%3Aopenai_key%7D%22%2C%22ANTHROPIC_API_KEY%22%3A%22%24%7Binput%3Aanthropic_key%7D%22%2C%22GOOGLE_API_KEY%22%3A%22%24%7Binput%3Agemini_key%7D%22%2C%22GROQ_API_KEY%22%3A%22%24%7Binput%3Agroq_key%7D%22%2C%22DEEPSEEK_API_KEY%22%3A%22%24%7Binput%3Adeepseek_key%7D%22%2C%22OLLAMA_HOST%22%3A%22http%3A%2F%2Flocalhost%3A11434%22%2C%22DEFAULT_MODEL%22%3A%22openai%3Agpt-4o-mini%22%2C%22DEFAULT_TEAM_MODELS%22%3A%22%5B%5C%22openai%3Agpt-4.1%5C%22%2C%5C%22anthropic%3Aclaude-3-7-sonnet%5C%22%2C%5C%22gemini%3Agemini-2.5-pro%5C%22%5D%22%2C%22DEFAULT_DECISION_MAKER_MODEL%22%3A%22openai%3Agpt-4o-mini%22%7D%2C%22inputs%22%3A%5B%7B%22id%22%3A%22openai_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22OpenAI%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22anthropic_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Anthropic%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22gemini_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Google%20Gemini%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22groq_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Groq%20API%20Key%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22deepseek_key%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22DeepSeek%20API%20Key%22%2C%22password%22%3Atrue%7D%5D%7D)
 
 ### Configure for Claude.app
 
@@ -63,17 +70,18 @@ To utilize this MCP server directly in other projects either use the buttons to 
       "args": [
         "--from",
         "git+https://github.com/danielscholl/agile-team-mcp-server@main",
-        "just-prompt",
-        "--default-models",
-        "high,openai:o4-mini:high,anthropic:claude-3-7-sonnet-20250219:4k,gemini:gemini-2.5-pro-preview-03-25,gemini:gemini-2.5-flash-preview-04-17"
+        "agile-team"
       ],
       "env": {
         "OPENAI_API_KEY": "<YOUR_OPENAI_KEY>",
         "ANTHROPIC_API_KEY": "<YOUR_ANTHROPIC_KEY>",
-        "GEMINI_API_KEY": "<YOUR_GEMINI_KEY>",
+        "GOOGLE_API_KEY": "<YOUR_GEMINI_KEY>",
         "GROQ_API_KEY": "<YOUR_GROQ_KEY>",
         "DEEPSEEK_API_KEY": "<YOUR_DEEPSEEK_KEY>",
-        "OLLAMA_HOST": "http://localhost:11434"
+        "OLLAMA_HOST": "http://localhost:11434",
+        "DEFAULT_MODEL": "openai:gpt-4o-mini",
+        "DEFAULT_TEAM_MODELS": "[\"openai:gpt-4.1\",\"anthropic:claude-3-7-sonnet\",\"gemini:gemini-2.5-pro\"]",
+        "DEFAULT_DECISION_MAKER_MODEL": "openai:gpt-4o-mini"
       }
     }
   }
@@ -94,7 +102,12 @@ claude mcp add-from-claude-desktop
 # Copy this JSON configuration
 {
     "command": "uvx",
-    "args": ["--from", "git+https://github.com/danielscholl/agile-team-mcp-server@main", "just-prompt", "--default-models", "high,openai:o4-mini:high,anthropic:claude-3-7-sonnet-20250219:4k,gemini:gemini-2.5-pro-preview-03-25,gemini:gemini-2.5-flash-preview-04-17"]
+    "args": ["--from", "git+https://github.com/danielscholl/agile-team-mcp-server@main", "agile-team"],
+    "env": {
+        "DEFAULT_MODEL": "openai:gpt-4o-mini",
+        "DEFAULT_TEAM_MODELS": "[\"openai:gpt-4.1\",\"anthropic:claude-3-7-sonnet\",\"gemini:gemini-2.5-pro\"]",
+        "DEFAULT_DECISION_MAKER_MODEL": "openai:gpt-4o-mini"
+    }
 }
 
 # Then run this command in Claude Code
@@ -140,63 +153,164 @@ mcp use agile-team
 
 ### List Available Options
 
-Check which providers and models are available for use.
+Tools to discover available LLM providers and their supported models.
 
+#### List Providers Tool
+
+Lists all supported LLM providers and their shortcut prefixes.
+
+**Parameters**: None required
+
+**Examples**:
 ```bash
-# List all providers
+# Simple example
 list_providers_tool
 
-# List models for a specific provider
+# For structured output (advanced usage)
+list_providers_tool > providers.json
+```
+
+#### List Models Tool
+
+Lists all available models for a specific provider.
+
+**Parameters**:
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `provider` | The provider to list models for (e.g., "openai", "anthropic") | *required* |
+
+**Examples**:
+```bash
+# Simple example with full provider name
 list_models_tool: "openai"
+
+# Using provider shortcode
+list_models_tool: "a"  # Lists Anthropic models
 ```
 
 ### Send Prompts to Models
 
-Process prompts from input message.
+Send text prompts directly to LLM models and get their responses.
 
-> Default decision maker model: `openai:o4-mini`
+**Parameters**:
 
-**Usage examples:**
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `text` | The prompt text to send to the models | *required* |
+| `models_prefixed_by_provider` | List of models in format "provider:model" | `openai:gpt-4o-mini` |
+
+**Features**:
+- Send prompts to one or multiple models simultaneously
+- Use model suffixes for special behaviors:
+  - `:4k` or other numbers for thinking token budgets
+  - `:high` for increased reasoning effort (OpenAI only)
+
+**Examples**:
 ```bash
-# Basic prompt with default model
-prompt_tool: "ping"
+# Simple example
+prompt_tool: "Create a plan for implementing user authentication"
 
-# Claude with 4k thinking tokens
-prompt_tool: "Analyze quantum computing applications" ["a:claude-3-7-sonnet-20250219:4k"]
-
-# OpenAI with high reasoning effort
-prompt_tool: "Write a function to calculate the factorial of a number" ["openai:o3-mini:high"]
-
-# Gemini with 8k thinking budget
-prompt_tool: "Evaluate climate change solutions" ["gemini:gemini-2.5-flash-preview-04-17:8k"]
+# Complex example with multiple models and options
+prompt_tool: "Analyze the trade-offs between microservices and monoliths" ["openai:gpt-4.1:high", "anthropic:claude-3-7-sonnet:4k", "gemini:gemini-2.5-pro"]
 ```
-
-- Default decision maker model: `openai:o4-mini`
 
 ### Work with Files
 
 Process prompts from files and save responses to files for batch processing.
 
-> Default decision maker model: `openai:o4-mini`
+#### From File Tool
 
+**Parameters**:
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `file_path` | Path to the file containing the prompt | *required* |
+| `models_prefixed_by_provider` | List of models in format "provider:model" | `openai:gpt-4o-mini` |
+
+**Examples**:
 ```bash
-# Send prompt from file
-prompt_from_file_tool: [a:claude-3-7-sonnet] "prompts/function.md"
+# Simple example
+prompt_from_file_tool: "prompts/function.md"
 
-# Save responses to files
+# Complex example with specific model
+prompt_from_file_tool: "prompts/function.md" ["anthropic:claude-3-7-sonnet-20250219:4k"]
+```
+
+#### From File to File Tool
+
+**Parameters**:
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `file_path` | Path to the file containing the prompt | *required* |
+| `models_prefixed_by_provider` | List of models in format "provider:model" | `openai:gpt-4o-mini` |
+| `output_path` | Full path for the output file | Generated based on input |
+| `output_dir` | Directory for response files | input file's directory/responses |
+| `output_extension` | File extension for output files | `md` |
+
+**Examples**:
+```bash
+# Simple example
 prompt_from_file2file_tool: "prompts/uv_script.md"
-prompt_from_file2file_tool: [a:claude-3-7-sonnet] "prompts/uv_script.md" "prompts/responses/uv_script.py"
-prompt_from_file2file_tool: [a:claude-3-7-sonnet] "prompts/diagram_request.txt" output_extension="md"
+
+# Complex example with specific model, output path and custom extension
+prompt_from_file2file_tool: "prompts/diagram.md" ["anthropic:claude-3-7-sonnet"] "prompts/responses/architecture_diagram.svg" output_extension="svg"
 ```
 
 ### Team Decision Making
 
 Use multiple models as team members to generate different solutions, then have a decision maker model evaluate and choose the best approach.
 
-> Default team member models: `["openai:gpt-4.1", "anthropic:claude-3-7-sonnet", "gemini:gemini-2.5-pro"]`
-> Default persona decision model: `openai:o4-mini`
+**Parameters**:
 
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `from_file` | Path to the file containing the prompt | *required* |
+| `models_prefixed_by_provider` | List of team member models | `["openai:gpt-4.1", "anthropic:claude-3-7-sonnet", "gemini:gemini-2.5-pro"]` |
+| `persona_dm_model` | Model for making the decision | `openai:gpt-4o-mini` |
+| `output_path` | Full path for the output document | Generated based on input |
+| `output_dir` | Directory for response files | input file's directory/responses |
+| `output_extension` | File extension for output files | `md` |
+| `persona_prompt` | Custom decision maker prompt | Default template |
+
+**Examples**:
 ```bash
-persona_dm_tool: "prompts/decision.md" ["o:gpt-4.1", "a:claude-3-7-sonnet", "g:gemini-2.5-pro"] "o:o4-mini" "prompts/responses/final_decision.md"
+# Simple example
+persona_dm_tool: "prompts/decision.md"
+
+# Complex example with custom team and decision maker model
+persona_dm_tool: "prompts/decision.md" ["openai:gpt-4.1", "anthropic:claude-3-7-sonnet", "gemini:gemini-2.5-pro"] persona_dm_model="anthropic:claude-3-7-sonnet" "prompts/responses/final_decision.md"
 ```
 
+### Business Analyst Persona
+
+Generate detailed business analysis using a specialized Business Analyst persona, with optional team-based decision making.
+
+**Capabilities**:
+- Creating detailed project briefs and requirement documents
+- Analyzing business needs and market opportunities
+- Defining MVP scope and feature prioritization
+- Identifying target audiences and user personas
+
+**Parameters**:
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `from_file` | Path to the file containing business requirements | *required* |
+| `models_prefixed_by_provider` | Models to use in format "provider:model" | `openai:gpt-4o-mini` |
+| `output_path` | Full path for the output document | Generated based on input |
+| `output_dir` | Directory for response files | input file's directory/responses |
+| `output_extension` | File extension for output files | `md` |
+| `use_decision_maker` | Whether to use team decision making | `false` |
+| `decision_maker_models` | Models for team members if using decision maker | `["openai:gpt-4.1", "anthropic:claude-3-7-sonnet", "gemini:gemini-2.5-pro"]` |
+| `decision_maker_model` | Model for final decision making | `openai:gpt-4o-mini` |
+
+**Examples**:
+```bash
+# Simple example
+persona_ba_tool: "prompts/product_requirements.md"
+
+# Complex example with team-based decision making
+persona_ba_tool: "prompts/product_requirements.md" use_decision_maker=true decision_maker_model="anthropic:claude-3-7-sonnet" "prompts/responses/team_business_analysis.md"
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Required API keys in your `.env` file:
 # Required API keys
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-GOOGLE_API_KEY=your_gemini_api_key_here  # For Gemini models
+GEMINI_API_KEY=your_gemini_api_key_here  # For Google Gemini models
 GROQ_API_KEY=your_groq_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
 OLLAMA_HOST=http://localhost:11434
@@ -75,7 +75,7 @@ To utilize this MCP server directly in other projects either use the buttons to 
       "env": {
         "OPENAI_API_KEY": "<YOUR_OPENAI_KEY>",
         "ANTHROPIC_API_KEY": "<YOUR_ANTHROPIC_KEY>",
-        "GOOGLE_API_KEY": "<YOUR_GEMINI_KEY>",
+        "GEMINI_API_KEY": "<YOUR_GEMINI_KEY>",
         "GROQ_API_KEY": "<YOUR_GROQ_KEY>",
         "DEEPSEEK_API_KEY": "<YOUR_DEEPSEEK_KEY>",
         "OLLAMA_HOST": "http://localhost:11434",

--- a/specs/tool-llm-as-a-ba.md
+++ b/specs/tool-llm-as-a-ba.md
@@ -1,0 +1,309 @@
+# Feature: LLM as a Business Analyst (Persona BA)
+
+> A tool for performing tasks typically handled by a Business Analyst, with optional decision-making integration.
+
+## Implementation Details
+
+The persona_ba tool provides a specialized analysis framework using a Business Analyst persona, built on a reusable persona architecture:
+
+- Creates a base persona function to handle common functionality for all personas
+- Leverages a specialized Business Analyst prompt template to analyze business requirements
+- Efficiently integrates with the persona_dm tool for team-based decision making
+- Returns detailed business analysis formatted in markdown
+
+### Centralized Model Configuration
+
+To maintain consistency across the application, we'll implement a centralized configuration module:
+
+```python
+# In src/agile_team/shared/config.py
+"""Centralized configuration for the Agile Team MCP Server."""
+
+# Default single model for all tools
+DEFAULT_MODEL = "openai:gpt-4o-mini"
+
+# Default team models for multi-model scenarios
+DEFAULT_TEAM_MODELS = ["openai:gpt-4.1", "anthropic:claude-3-7-sonnet", "gemini:gemini-2.5-pro"]
+
+# Default decision maker model
+DEFAULT_DECISION_MAKER_MODEL = "openai:gpt-4o-mini"  # Uses the same default as standard operations
+```
+
+All tools will import these settings from the central config file, ensuring consistency throughout the application.
+
+### Reusable Persona Architecture
+
+To enable easy onboarding of multiple personas, we'll implement a base persona function that all specific personas can use:
+
+```python
+def persona_base(
+    persona_name: str,
+    persona_prompt: str,
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+```
+
+Then each specific persona becomes a lightweight wrapper around this base function:
+
+```python
+def persona_ba(
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    ba_prompt: str = DEFAULT_BA_PROMPT,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+    """
+    Business Analyst persona implementation.
+    """
+    return persona_base(
+        persona_name="business_analyst",
+        persona_prompt=ba_prompt,
+        from_file=from_file,
+        models_prefixed_by_provider=models_prefixed_by_provider,
+        output_dir=output_dir,
+        output_extension=output_extension,
+        output_path=output_path,
+        use_decision_maker=use_decision_maker,
+        decision_maker_models=decision_maker_models,
+        decision_maker_model=decision_maker_model,
+        decision_maker_prompt=decision_maker_prompt
+    )
+```
+
+### Core Function Signatures
+
+#### Base Persona Function
+
+```python
+def persona_base(
+    persona_name: str,
+    persona_prompt: str,
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+```
+
+#### Business Analyst Persona
+
+```python
+def persona_ba(
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    ba_prompt: str = DEFAULT_BA_PROMPT,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+```
+
+### Business Analyst Prompt Template
+
+```xml
+<purpose>
+    You are a world-class expert Market & Business Analyst and also the best research assistant I have ever met, possessing deep expertise in both comprehensive market research and collaborative project definition. 
+    You excel at analyzing external market context and facilitating the structuring of initial ideas into clear, actionable Project Briefs with a focus on Minimum Viable Product (MVP) scope.
+</purpose>
+
+<capabilities>
+    <capability>Data analysis and business needs understanding</capability>
+    <capability>Market opportunity and pain point identification</capability>
+    <capability>Competitor analysis</capability>
+    <capability>Target audience definition</capability>
+    <capability>Clear communication and structured dialogue</capability>
+</capabilities>
+
+<modes>   
+    <mode>
+        <n>Project Briefing Mode</n>
+        <description>Collaboratively guide the user through brainstorming and definition</description>
+        <outputs>
+            <o>Core Problem</o>
+            <o>Goals</o>
+            <o>Audience</o>
+            <o>Core Concept/Features (High-Level)</o>
+            <o>MVP Scope (In/Out)</o>
+            <o>Initial Technical Leanings (Optional)</o>
+        </outputs>
+        <tone>Detailed, knowledgeable, structured, professional</tone>
+    </mode>
+</modes>
+
+<instructions>
+    <instruction>Identify the required mode (Market Research or Project Briefing) based on the user's request. If unclear, assume Project Briefing Mode.</instruction>
+    <instruction>For Market Research Mode: Focus on executing deep research based on the provided concept. Present findings clearly and concisely in the final report.</instruction>
+    <instruction>For Project Briefing Mode: Engage in analysis of the concept, problem, goals, users, and MVP scope.</instruction>
+    <instruction>Use structured formats (lists, sections) for outputs and avoid ambiguity.</instruction>
+    <instruction>Ensure your project brief is well-structured, clear, and actionable.</instruction>
+    <instruction>Prioritize understanding user needs and project goals.</instruction>
+    <instruction>Be capable of explaining market concepts or analysis techniques clearly if requested.</instruction>
+    <instruction>Create a project brief that is well-structured, just like a real business analyst would.</instruction>
+    <instruction>Do not include any metadata, headers, footers, or formatting that isn't part of the actual project brief.</instruction>
+    <instruction>Do not ask additional questions, just provide the requested output.</instruction>
+</instructions>
+
+<interaction-flow>
+    <step>Identify Mode: Determine if the user needs Market Research or Project Briefing</step>
+    <step>Input Analysis: Analyze the provided information based on the identified mode</step>
+    <step>Execution: Perform research or guide through project definition</step>
+    <step>Output Generation: Structure findings into appropriate format</step>
+    <step>Presentation: Present final report or Project Brief document</step>
+</interaction-flow>
+
+<analyst-request>{analyst_request}</analyst-request>
+```
+
+### Implementation Logic
+
+1. **Base Persona Function Implementation**:
+   - Common parameter handling and validation
+   - Uses centralized model configuration
+   - Single-model and decision maker workflows
+   - File path and error handling logic
+
+2. **Single Model Flow** (when `use_decision_maker` is False):
+   - If no model specified, uses DEFAULT_MODEL
+   - Reads prompt from file
+   - Formats with persona template
+   - Sends to specified model
+   - Saves and returns output path
+
+3. **Decision Maker Flow** (when `use_decision_maker` is True):
+   - If no decision maker models specified, uses DEFAULT_TEAM_MODELS
+   - Creates a temporary prompt file with the persona prompt and original prompt contents
+   - Leverages existing `persona_dm` function to handle the team decision process
+   - Uses DEFAULT_DECISION_MAKER_MODEL if no decision maker model specified
+   - Returns the decision maker result path
+
+4. **File Path Handling**:
+   - File naming based on persona name and model details
+   - Consistent with existing file path conventions in other tools
+
+### MCP Tool Registration
+
+Register the Business Analyst tool in server.py:
+
+```python
+@mcp.tool()
+def persona_ba_tool(
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    ba_prompt: str = DEFAULT_BA_PROMPT,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+    """
+    Generate business analysis using a specialized Business Analyst persona, with optional decision making.
+    
+    This tool uses a specialized Business Analyst prompt to analyze business requirements
+    from a file. It can either use a single model or leverage the team decision-making
+    functionality to get multiple perspectives and consolidate them.
+    
+    Args:
+        from_file: Path to the file containing the business requirements
+        models_prefixed_by_provider: List of models in format "provider:model"
+                                    (if None, defaults to DEFAULT_MODEL)
+        output_dir: Directory where response files should be saved (defaults to input file's directory/responses)
+        output_extension: File extension for output files (e.g., 'py', 'txt', 'md')
+        output_path: Optional full output path with filename for the output document
+        use_decision_maker: Whether to use the decision maker functionality
+        decision_maker_models: Models to use if use_decision_maker is True
+                             (if None, defaults to DEFAULT_TEAM_MODELS)
+        ba_prompt: Custom business analyst prompt template
+        decision_maker_model: Model to use for decision making (defaults to DEFAULT_DECISION_MAKER_MODEL)
+        decision_maker_prompt: Custom persona prompt template for decision making
+    
+    Returns:
+        Path to the business analysis output file
+    """
+    return persona_ba(
+        from_file=from_file,
+        models_prefixed_by_provider=models_prefixed_by_provider,
+        output_dir=output_dir,
+        output_extension=output_extension,
+        output_path=output_path,
+        use_decision_maker=use_decision_maker,
+        decision_maker_models=decision_maker_models,
+        ba_prompt=ba_prompt,
+        decision_maker_model=decision_maker_model,
+        decision_maker_prompt=decision_maker_prompt
+    )
+```
+
+## Relevant Files
+
+- src/agile_team/shared/config.py - New file for centralized configuration
+- src/agile_team/server.py - Updated to use centralized configuration
+- src/agile_team/tools/persona_base.py - New file with core reusable persona logic
+- src/agile_team/tools/persona_ba.py - Business Analyst persona implementation
+- src/agile_team/tools/persona_dm.py - Updated to use centralized configuration
+- src/agile_team/shared/model_router.py - Used for model validation and prompting
+- src/agile_team/shared/utils.py - File operations and utilities
+- src/agile_team/tests/tools/test_persona_base.py - Test cases for base functionality
+- src/agile_team/tests/tools/test_persona_ba.py - Test cases for BA implementation
+
+## Testing Requirements
+
+Tests should cover:
+- Base persona functionality in isolation
+- Business Analyst implementation 
+- Integration with decision maker when use_decision_maker is True
+- Parameter validation and error handling
+- Various output path configurations
+- Custom prompt template usage
+
+## Validation
+
+- Run tests with `uv run pytest src/agile_team/tests/tools/test_persona_ba.py`
+- Verify end-to-end functionality with sample prompts
+- Validate MCP tool registration with `uv run agile-team --help`
+- Update README.md with documentation for the new tool
+
+## Future Persona Implementation
+
+This architecture makes it easy to add additional personas in the future:
+
+```python
+def persona_product_manager(...):
+    return persona_base(
+        persona_name="product_manager",
+        persona_prompt=DEFAULT_PM_PROMPT,
+        ...
+    )
+
+def persona_data_scientist(...):
+    return persona_base(
+        persona_name="data_scientist",
+        persona_prompt=DEFAULT_DS_PROMPT,
+        ...
+    )
+```

--- a/src/agile_team/server.py
+++ b/src/agile_team/server.py
@@ -1,7 +1,7 @@
 """MCP Server implementation for Agile Team."""
 
 from mcp.server.fastmcp import FastMCP
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 # Import tools
 from agile_team.tools.prompt import prompt
@@ -112,10 +112,10 @@ def list_models_tool(provider: str) -> List[str]:
 @mcp.tool()
 def persona_dm_tool(
     from_file: str,
-    models_prefixed_by_provider: List[str] = None,
-    output_dir: str = None,
-    output_extension: str = None,
-    output_path: str = None,
+    models_prefixed_by_provider: Optional[List[str]] = None,
+    output_dir: Optional[str] = None,
+    output_extension: Optional[str] = None,
+    output_path: Optional[str] = None,
     persona_dm_model: str = DEFAULT_DECISION_MAKER_MODEL, 
     persona_prompt: str = DEFAULT_PERSONA_PROMPT
 ) -> str:
@@ -152,12 +152,12 @@ def persona_dm_tool(
 @mcp.tool()
 def persona_ba_tool(
     from_file: str,
-    models_prefixed_by_provider: List[str] = None,
-    output_dir: str = None,
-    output_extension: str = None,
-    output_path: str = None,
+    models_prefixed_by_provider: Optional[List[str]] = None,
+    output_dir: Optional[str] = None,
+    output_extension: Optional[str] = None,
+    output_path: Optional[str] = None,
     use_decision_maker: bool = False,
-    decision_maker_models: List[str] = None,
+    decision_maker_models: Optional[List[str]] = None,
     ba_prompt: str = DEFAULT_BA_PROMPT,
     decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
     decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT

--- a/src/agile_team/server.py
+++ b/src/agile_team/server.py
@@ -9,10 +9,14 @@ from agile_team.tools.prompt_from_file import prompt_from_file
 from agile_team.tools.prompt_from_file_to_file import prompt_from_file_to_file
 from agile_team.tools.list_providers import list_providers
 from agile_team.tools.list_models import list_models
-from agile_team.tools.persona_dm import persona_dm, DEFAULT_PERSONA_DM_MODEL, DEFAULT_PERSONA_PROMPT
+from agile_team.tools.persona_dm import persona_dm, DEFAULT_PERSONA_PROMPT
+from agile_team.tools.persona_ba import persona_ba, DEFAULT_BA_PROMPT
 
-# Default model for prompt tools
-DEFAULT_PROMPT_MODEL = ["openai:gpt-4o-mini"]
+# Import centralized configuration
+from agile_team.shared.config import DEFAULT_MODEL, DEFAULT_TEAM_MODELS, DEFAULT_DECISION_MAKER_MODEL
+
+# Default model for prompt tools (maintained for backward compatibility)
+DEFAULT_PROMPT_MODEL = [DEFAULT_MODEL]
 
 # Create a FastMCP server instance
 mcp = FastMCP("Agile Team MCP Server")
@@ -112,7 +116,7 @@ def persona_dm_tool(
     output_dir: str = None,
     output_extension: str = None,
     output_path: str = None,
-    persona_dm_model: str = DEFAULT_PERSONA_DM_MODEL, 
+    persona_dm_model: str = DEFAULT_DECISION_MAKER_MODEL, 
     persona_prompt: str = DEFAULT_PERSONA_PROMPT
 ) -> str:
     """
@@ -128,7 +132,7 @@ def persona_dm_tool(
         output_dir: Directory where response files should be saved (defaults to input file's directory/responses)
         output_extension: File extension for output files (e.g., 'py', 'txt', 'md')
         output_path: Optional full output path with filename for the persona document
-        persona_dm_model: Model to use for making the decision (defaults to "openai:o4-mini")
+        persona_dm_model: Model to use for making the decision (defaults to DEFAULT_DECISION_MAKER_MODEL)
         persona_prompt: Custom persona prompt template (if None, uses the default)
     
     Returns:
@@ -142,4 +146,55 @@ def persona_dm_tool(
         output_path=output_path,
         persona_dm_model=persona_dm_model,
         persona_prompt=persona_prompt
+    )
+
+
+@mcp.tool()
+def persona_ba_tool(
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    ba_prompt: str = DEFAULT_BA_PROMPT,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+    """
+    Generate business analysis using a specialized Business Analyst persona, with optional decision making.
+    
+    This tool uses a specialized Business Analyst prompt to analyze business requirements
+    from a file. It can either use a single model or leverage the team decision-making
+    functionality to get multiple perspectives and consolidate them.
+    
+    Args:
+        from_file: Path to the file containing the business requirements
+        models_prefixed_by_provider: List of models in format "provider:model"
+                                    (if None, defaults to DEFAULT_MODEL)
+        output_dir: Directory where response files should be saved (defaults to input file's directory/responses)
+        output_extension: File extension for output files (e.g., 'py', 'txt', 'md')
+        output_path: Optional full output path with filename for the output document
+        use_decision_maker: Whether to use the decision maker functionality
+        decision_maker_models: Models to use if use_decision_maker is True
+                             (if None, defaults to DEFAULT_TEAM_MODELS)
+        ba_prompt: Custom business analyst prompt template
+        decision_maker_model: Model to use for decision making (defaults to DEFAULT_DECISION_MAKER_MODEL)
+        decision_maker_prompt: Custom persona prompt template for decision making
+    
+    Returns:
+        Path to the business analysis output file
+    """
+    return persona_ba(
+        from_file=from_file,
+        models_prefixed_by_provider=models_prefixed_by_provider,
+        output_dir=output_dir,
+        output_extension=output_extension,
+        output_path=output_path,
+        use_decision_maker=use_decision_maker,
+        decision_maker_models=decision_maker_models,
+        ba_prompt=ba_prompt,
+        decision_maker_model=decision_maker_model,
+        decision_maker_prompt=decision_maker_prompt
     )

--- a/src/agile_team/shared/config.py
+++ b/src/agile_team/shared/config.py
@@ -1,0 +1,10 @@
+"""Centralized configuration for the Agile Team MCP Server."""
+
+# Default single model for all tools
+DEFAULT_MODEL = "openai:gpt-4o-mini"
+
+# Default team models for multi-model scenarios
+DEFAULT_TEAM_MODELS = ["openai:gpt-4.1", "anthropic:claude-3-7-sonnet", "gemini:gemini-2.5-pro"]
+
+# Default decision maker model
+DEFAULT_DECISION_MAKER_MODEL = "openai:gpt-4o-mini"

--- a/src/agile_team/tests/tools/test_persona_ba.py
+++ b/src/agile_team/tests/tools/test_persona_ba.py
@@ -1,0 +1,116 @@
+"""Tests for the Business Analyst persona implementation."""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import patch, MagicMock
+
+from agile_team.tools.persona_ba import persona_ba, DEFAULT_BA_PROMPT
+from agile_team.shared.config import DEFAULT_MODEL, DEFAULT_TEAM_MODELS, DEFAULT_DECISION_MAKER_MODEL
+
+
+class TestPersonaBa:
+    """Tests for the Business Analyst persona functionality."""
+    
+    def setup_method(self):
+        """Setup for each test method."""
+        self.test_content = "Create a project brief for a mobile app that helps users track their daily water intake."
+        
+        # Create a temporary file with test content
+        self.temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.temp_file.write(self.test_content)
+        self.temp_file.close()
+    
+    def teardown_method(self):
+        """Teardown for each test method."""
+        if os.path.exists(self.temp_file.name):
+            os.unlink(self.temp_file.name)
+    
+    @patch('agile_team.tools.persona_ba.persona_base')
+    def test_persona_ba_default_parameters(self, mock_persona_base):
+        """Test the Business Analyst persona with default parameters."""
+        # Setup
+        expected_output = "/path/to/output.md"
+        mock_persona_base.return_value = expected_output
+        
+        # Execute
+        result = persona_ba(from_file=self.temp_file.name)
+        
+        # Verify
+        assert result == expected_output
+        mock_persona_base.assert_called_once()
+        
+        # Check that persona_base was called with the correct parameters
+        call_kwargs = mock_persona_base.call_args[1]
+        assert call_kwargs['persona_name'] == "business_analyst"
+        assert call_kwargs['persona_prompt'] == DEFAULT_BA_PROMPT
+        assert call_kwargs['from_file'] == self.temp_file.name
+        assert call_kwargs['use_decision_maker'] == False
+        assert call_kwargs['decision_maker_model'] == DEFAULT_DECISION_MAKER_MODEL
+    
+    @patch('agile_team.tools.persona_ba.persona_base')
+    def test_persona_ba_with_decision_maker(self, mock_persona_base):
+        """Test the Business Analyst persona with decision maker enabled."""
+        # Setup
+        expected_output = "/path/to/decision.md"
+        mock_persona_base.return_value = expected_output
+        
+        # Execute
+        result = persona_ba(
+            from_file=self.temp_file.name,
+            use_decision_maker=True,
+            decision_maker_models=["openai:model1", "anthropic:model2"]
+        )
+        
+        # Verify
+        assert result == expected_output
+        mock_persona_base.assert_called_once()
+        
+        # Check that persona_base was called with the correct parameters
+        call_kwargs = mock_persona_base.call_args[1]
+        assert call_kwargs['persona_name'] == "business_analyst"
+        assert call_kwargs['use_decision_maker'] == True
+        assert call_kwargs['decision_maker_models'] == ["openai:model1", "anthropic:model2"]
+    
+    @patch('agile_team.tools.persona_ba.persona_base')
+    def test_persona_ba_custom_prompt(self, mock_persona_base):
+        """Test the Business Analyst persona with a custom prompt."""
+        # Setup
+        expected_output = "/path/to/output.md"
+        mock_persona_base.return_value = expected_output
+        custom_prompt = "<custom>Test prompt {analyst_request}</custom>"
+        
+        # Execute
+        result = persona_ba(
+            from_file=self.temp_file.name,
+            ba_prompt=custom_prompt
+        )
+        
+        # Verify
+        assert result == expected_output
+        mock_persona_base.assert_called_once()
+        
+        # Check that persona_base was called with the correct parameters
+        call_kwargs = mock_persona_base.call_args[1]
+        assert call_kwargs['persona_prompt'] == custom_prompt
+    
+    @patch('agile_team.tools.persona_ba.persona_base')
+    def test_persona_ba_output_path_handling(self, mock_persona_base):
+        """Test the Business Analyst persona with custom output path."""
+        # Setup
+        expected_output = "/custom/path/output.md"
+        mock_persona_base.return_value = expected_output
+        
+        # Execute
+        result = persona_ba(
+            from_file=self.temp_file.name,
+            output_path=expected_output
+        )
+        
+        # Verify
+        assert result == expected_output
+        mock_persona_base.assert_called_once()
+        
+        # Check that persona_base was called with the correct parameters
+        call_kwargs = mock_persona_base.call_args[1]
+        assert call_kwargs['output_path'] == expected_output

--- a/src/agile_team/tests/tools/test_persona_base.py
+++ b/src/agile_team/tests/tools/test_persona_base.py
@@ -1,0 +1,110 @@
+"""Tests for the base persona implementation."""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import patch, MagicMock
+
+from agile_team.tools.persona_base import persona_base, _run_with_single_model, _run_with_decision_maker
+from agile_team.shared.config import DEFAULT_MODEL, DEFAULT_TEAM_MODELS, DEFAULT_DECISION_MAKER_MODEL
+
+
+class TestPersonaBase:
+    """Tests for the persona_base functionality."""
+    
+    def setup_method(self):
+        """Setup for each test method."""
+        self.test_prompt = "<purpose>Test purpose</purpose>\n<test-request>{analyst_request}</test-request>"
+        self.test_content = "Test content for analysis"
+        
+        # Create a temporary file with test content
+        self.temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.temp_file.write(self.test_content)
+        self.temp_file.close()
+    
+    def teardown_method(self):
+        """Teardown for each test method."""
+        if os.path.exists(self.temp_file.name):
+            os.unlink(self.temp_file.name)
+    
+    @patch('agile_team.tools.persona_base.prompt_model')
+    @patch('agile_team.tools.persona_base.write_file')
+    def test_single_model_workflow(self, mock_write_file, mock_prompt_model):
+        """Test the single model workflow."""
+        # Setup
+        mock_prompt_model.return_value = "Model response"
+        mock_write_file.return_value = None
+        
+        # Create a temporary output directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Execute
+            result = persona_base(
+                persona_name="test_persona",
+                persona_prompt=self.test_prompt,
+                from_file=self.temp_file.name,
+                output_dir=temp_dir
+            )
+            
+            # Verify
+            assert result is not None
+            assert temp_dir in result
+            assert "test_persona" in result
+            mock_prompt_model.assert_called_once()
+            expected_prompt = self.test_prompt.format(analyst_request=self.test_content)
+            assert mock_prompt_model.call_args[0][2] == expected_prompt
+            mock_write_file.assert_called_once()
+    
+    @patch('agile_team.tools.persona_base.persona_dm')
+    def test_decision_maker_workflow(self, mock_persona_dm):
+        """Test the decision maker workflow."""
+        # Setup
+        expected_output = "/path/to/result.md"
+        mock_persona_dm.return_value = expected_output
+        
+        # Execute
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = persona_base(
+                persona_name="test_persona",
+                persona_prompt=self.test_prompt,
+                from_file=self.temp_file.name,
+                output_dir=temp_dir,
+                use_decision_maker=True
+            )
+            
+            # Verify
+            assert result == expected_output
+            mock_persona_dm.assert_called_once()
+            # Verify the temporary file being created and passed to persona_dm
+            temp_file_path = mock_persona_dm.call_args[1]['from_file']
+            assert os.path.exists(temp_file_path) == False  # Should be deleted after use
+    
+    def test_default_model_handling(self):
+        """Test that default models are handled correctly."""
+        with patch('agile_team.tools.persona_base._run_with_single_model') as mock_single:
+            mock_single.return_value = "result.md"
+            
+            # Without specifying a model, should use DEFAULT_MODEL
+            persona_base(
+                persona_name="test",
+                persona_prompt="test",
+                from_file=self.temp_file.name
+            )
+            
+            # Verify DEFAULT_MODEL was used
+            assert mock_single.call_args[1]['models_prefixed_by_provider'] == [DEFAULT_MODEL]
+    
+    def test_default_decision_maker_models_handling(self):
+        """Test that default decision maker models are handled correctly."""
+        with patch('agile_team.tools.persona_base._run_with_decision_maker') as mock_dm:
+            mock_dm.return_value = "result.md"
+            
+            # Without specifying decision maker models, should use DEFAULT_TEAM_MODELS
+            persona_base(
+                persona_name="test",
+                persona_prompt="test",
+                from_file=self.temp_file.name,
+                use_decision_maker=True
+            )
+            
+            # Verify DEFAULT_TEAM_MODELS was passed
+            assert mock_dm.call_args[1]['decision_maker_models'] == DEFAULT_TEAM_MODELS

--- a/src/agile_team/tools/persona_ba.py
+++ b/src/agile_team/tools/persona_ba.py
@@ -1,6 +1,6 @@
 """Business Analyst persona implementation."""
 
-from typing import List
+from typing import List, Optional
 from agile_team.shared.config import DEFAULT_MODEL, DEFAULT_TEAM_MODELS, DEFAULT_DECISION_MAKER_MODEL
 from agile_team.tools.persona_base import persona_base
 from agile_team.tools.persona_dm import DEFAULT_PERSONA_PROMPT
@@ -63,12 +63,12 @@ DEFAULT_BA_PROMPT = """
 
 def persona_ba(
     from_file: str,
-    models_prefixed_by_provider: List[str] = None,
-    output_dir: str = None,
-    output_extension: str = None,
-    output_path: str = None,
+    models_prefixed_by_provider: Optional[List[str]] = None,
+    output_dir: Optional[str] = None,
+    output_extension: Optional[str] = None,
+    output_path: Optional[str] = None,
     use_decision_maker: bool = False,
-    decision_maker_models: List[str] = None,
+    decision_maker_models: Optional[List[str]] = None,
     ba_prompt: str = DEFAULT_BA_PROMPT,
     decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
     decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT

--- a/src/agile_team/tools/persona_ba.py
+++ b/src/agile_team/tools/persona_ba.py
@@ -1,0 +1,108 @@
+"""Business Analyst persona implementation."""
+
+from typing import List
+from agile_team.shared.config import DEFAULT_MODEL, DEFAULT_TEAM_MODELS, DEFAULT_DECISION_MAKER_MODEL
+from agile_team.tools.persona_base import persona_base
+from agile_team.tools.persona_dm import DEFAULT_PERSONA_PROMPT
+
+# Default Business Analyst prompt template
+DEFAULT_BA_PROMPT = """
+<purpose>
+    You are a world-class expert Market & Business Analyst and also the best research assistant I have ever met, possessing deep expertise in both comprehensive market research and collaborative project definition. 
+    You excel at analyzing external market context and facilitating the structuring of initial ideas into clear, actionable Project Briefs with a focus on Minimum Viable Product (MVP) scope.
+</purpose>
+
+<capabilities>
+    <capability>Data analysis and business needs understanding</capability>
+    <capability>Market opportunity and pain point identification</capability>
+    <capability>Competitor analysis</capability>
+    <capability>Target audience definition</capability>
+    <capability>Clear communication and structured dialogue</capability>
+</capabilities>
+
+<modes>   
+    <mode>
+        <n>Project Briefing Mode</n>
+        <description>Collaboratively guide the user through brainstorming and definition</description>
+        <outputs>
+            <o>Core Problem</o>
+            <o>Goals</o>
+            <o>Audience</o>
+            <o>Core Concept/Features (High-Level)</o>
+            <o>MVP Scope (In/Out)</o>
+            <o>Initial Technical Leanings (Optional)</o>
+        </outputs>
+        <tone>Detailed, knowledgeable, structured, professional</tone>
+    </mode>
+</modes>
+
+<instructions>
+    <instruction>Identify the required mode (Market Research or Project Briefing) based on the user's request. If unclear, assume Project Briefing Mode.</instruction>
+    <instruction>For Market Research Mode: Focus on executing deep research based on the provided concept. Present findings clearly and concisely in the final report.</instruction>
+    <instruction>For Project Briefing Mode: Engage in analysis of the concept, problem, goals, users, and MVP scope.</instruction>
+    <instruction>Use structured formats (lists, sections) for outputs and avoid ambiguity.</instruction>
+    <instruction>Ensure your project brief is well-structured, clear, and actionable.</instruction>
+    <instruction>Prioritize understanding user needs and project goals.</instruction>
+    <instruction>Be capable of explaining market concepts or analysis techniques clearly if requested.</instruction>
+    <instruction>Create a project brief that is well-structured, just like a real business analyst would.</instruction>
+    <instruction>Do not include any metadata, headers, footers, or formatting that isn't part of the actual project brief.</instruction>
+    <instruction>Do not ask additional questions, just provide the requested output.</instruction>
+</instructions>
+
+<interaction-flow>
+    <step>Identify Mode: Determine if the user needs Market Research or Project Briefing</step>
+    <step>Input Analysis: Analyze the provided information based on the identified mode</step>
+    <step>Execution: Perform research or guide through project definition</step>
+    <step>Output Generation: Structure findings into appropriate format</step>
+    <step>Presentation: Present final report or Project Brief document</step>
+</interaction-flow>
+
+<analyst-request>{analyst_request}</analyst-request>
+"""
+
+
+def persona_ba(
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    ba_prompt: str = DEFAULT_BA_PROMPT,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+    """
+    Business Analyst persona implementation.
+    
+    Args:
+        from_file: Path to the file containing the business requirements
+        models_prefixed_by_provider: List of models in format "provider:model"
+                                    (if None, defaults to DEFAULT_MODEL)
+        output_dir: Directory where response files should be saved (defaults to input file's directory/responses)
+        output_extension: File extension for output files (e.g., 'py', 'txt', 'md')
+        output_path: Optional full output path with filename for the output document
+        use_decision_maker: Whether to use the decision maker functionality
+        decision_maker_models: Models to use if use_decision_maker is True
+                             (if None, defaults to DEFAULT_TEAM_MODELS)
+        ba_prompt: Custom business analyst prompt template
+        decision_maker_model: Model to use for decision making (defaults to DEFAULT_DECISION_MAKER_MODEL)
+        decision_maker_prompt: Custom persona prompt template for decision making
+    
+    Returns:
+        Path to the business analysis output file
+    """
+    return persona_base(
+        persona_name="business_analyst",
+        persona_prompt=ba_prompt,
+        from_file=from_file,
+        models_prefixed_by_provider=models_prefixed_by_provider,
+        output_dir=output_dir,
+        output_extension=output_extension,
+        output_path=output_path,
+        use_decision_maker=use_decision_maker,
+        decision_maker_models=decision_maker_models,
+        decision_maker_model=decision_maker_model,
+        decision_maker_prompt=decision_maker_prompt
+    )

--- a/src/agile_team/tools/persona_base.py
+++ b/src/agile_team/tools/persona_base.py
@@ -1,0 +1,248 @@
+"""Base persona implementation for reusable persona functionality."""
+
+import os
+import tempfile
+from typing import List, Optional
+from mcp.server.fastmcp.exceptions import ValidationError, ToolError, ResourceError
+
+from agile_team.shared.config import DEFAULT_MODEL, DEFAULT_TEAM_MODELS, DEFAULT_DECISION_MAKER_MODEL
+from agile_team.shared.validator import validate_and_correct_models
+from agile_team.shared.model_router import prompt_model
+from agile_team.shared.utils import read_file, write_file
+from agile_team.tools.persona_dm import persona_dm, DEFAULT_PERSONA_PROMPT
+
+
+def persona_base(
+    persona_name: str,
+    persona_prompt: str,
+    from_file: str,
+    models_prefixed_by_provider: List[str] = None,
+    output_dir: str = None,
+    output_extension: str = None,
+    output_path: str = None,
+    use_decision_maker: bool = False,
+    decision_maker_models: List[str] = None,
+    decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
+    decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
+) -> str:
+    """
+    Base function for all personas, providing common functionality.
+    
+    Args:
+        persona_name: Name of the persona (e.g., "business_analyst")
+        persona_prompt: The prompt template for the persona
+        from_file: Path to the file containing the input text
+        models_prefixed_by_provider: List of models to use (if None and not using decision maker, uses DEFAULT_MODEL as a single item list)
+        output_dir: Directory where response files should be saved
+        output_extension: File extension for output files
+        output_path: Optional full output path with filename
+        use_decision_maker: Whether to use the decision maker functionality
+        decision_maker_models: Models to use if use_decision_maker is True (if None, uses DEFAULT_TEAM_MODELS)
+        decision_maker_model: Model to use for decision making (defaults to DEFAULT_DECISION_MAKER_MODEL)
+        decision_maker_prompt: Custom persona prompt template for decision making
+    
+    Returns:
+        Path to the output file
+    """
+    # Set default models if none provided
+    if models_prefixed_by_provider is None:
+        models_prefixed_by_provider = [DEFAULT_MODEL]
+        
+    # Set default decision maker models if none provided
+    if decision_maker_models is None:
+        decision_maker_models = DEFAULT_TEAM_MODELS
+    
+    # Handle path parameters based on input
+    if output_path and output_dir is None:
+        # Extract directory from output_path
+        output_directory = os.path.dirname(output_path) or "."
+    elif output_dir is None:
+        # Use from_file's directory + responses by default
+        input_file_dir = os.path.dirname(from_file) or "."
+        output_directory = os.path.join(input_file_dir, "responses")
+    else:
+        # Use provided output_dir
+        output_directory = output_dir
+        
+    # Ensure the output directory exists
+    os.makedirs(output_directory, exist_ok=True)
+    
+    # Read the content from the input file
+    try:
+        input_content = read_file(from_file)
+    except ResourceError as e:
+        raise ResourceError(f"Failed to read input file: {str(e)}")
+    
+    # Format the persona prompt with the input content
+    formatted_prompt = persona_prompt.format(analyst_request=input_content)
+    
+    if use_decision_maker:
+        # Use the decision maker workflow
+        return _run_with_decision_maker(
+            persona_name=persona_name,
+            formatted_prompt=formatted_prompt,
+            from_file=from_file,
+            decision_maker_models=decision_maker_models,
+            output_directory=output_directory,
+            output_extension=output_extension,
+            output_path=output_path,
+            decision_maker_model=decision_maker_model,
+            decision_maker_prompt=decision_maker_prompt
+        )
+    else:
+        # Use the single model workflow
+        return _run_with_single_model(
+            persona_name=persona_name,
+            formatted_prompt=formatted_prompt,
+            from_file=from_file,
+            models_prefixed_by_provider=models_prefixed_by_provider,
+            output_directory=output_directory,
+            output_extension=output_extension,
+            output_path=output_path
+        )
+
+
+def _run_with_single_model(
+    persona_name: str,
+    formatted_prompt: str,
+    from_file: str,
+    models_prefixed_by_provider: List[str],
+    output_directory: str,
+    output_extension: str,
+    output_path: str
+) -> str:
+    """Run a persona with a single model."""
+    # Validate models
+    validated_models = validate_and_correct_models(models_prefixed_by_provider)
+    if not validated_models:
+        raise ValidationError(f"Invalid models: {models_prefixed_by_provider}")
+    
+    # Extract the provider and model (only use the first one)
+    provider, model = validated_models[0]
+    
+    try:
+        # Get response from the model
+        response = prompt_model(provider, model, formatted_prompt)
+        
+        # Handle the output path
+        if output_path:
+            # Use the exact path specified
+            result_file_path = output_path
+            # Ensure parent directory exists
+            os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        else:
+            # Determine the file extension to use (.md by default)
+            extension = ".md"
+            if output_extension:
+                extension = output_extension if output_extension.startswith(".") else f".{output_extension}"
+                
+            # Extract base name from input file
+            base_filename = os.path.basename(from_file)
+            file_name, _ = os.path.splitext(base_filename)
+            
+            # Create the output filename with persona and model info
+            model_info = f"{provider}_{model}".replace(":", "_")
+            output_filename = f"{file_name}_{persona_name}_{model_info}{extension}"
+            result_file_path = os.path.join(output_directory, output_filename)
+        
+        # Write the response to the output file
+        write_file(result_file_path, response)
+        
+        return result_file_path
+        
+    except Exception as e:
+        # Handle errors when getting a response
+        error_message = f"Error getting response from {provider}:{model}: {str(e)}"
+        
+        # Determine error file path
+        if output_path:
+            # Create error file next to the specified output path
+            dir_path = os.path.dirname(output_path) or "."
+            base_name = os.path.basename(output_path)
+            name, ext = os.path.splitext(base_name)
+            error_file_path = os.path.join(dir_path, f"{name}_error{ext}")
+        else:
+            # Create standard error file in the output directory
+            base_filename = os.path.basename(from_file)
+            file_name, _ = os.path.splitext(base_filename)
+            extension = ".md"
+            if output_extension:
+                extension = output_extension if output_extension.startswith(".") else f".{output_extension}"
+            error_file_path = os.path.join(output_directory, f"{file_name}_{persona_name}_error{extension}")
+        
+        # Ensure parent directory exists
+        os.makedirs(os.path.dirname(error_file_path) or ".", exist_ok=True)
+        
+        # Write error to file
+        write_file(error_file_path, error_message)
+        raise ToolError(error_message)
+
+
+def _run_with_decision_maker(
+    persona_name: str,
+    formatted_prompt: str,
+    from_file: str,
+    decision_maker_models: List[str],
+    output_directory: str,
+    output_extension: str,
+    output_path: str,
+    decision_maker_model: str,
+    decision_maker_prompt: str
+) -> str:
+    """Run a persona with the decision maker functionality."""
+    try:
+        # Create a temporary file with the persona prompt
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as temp_file:
+            temp_file_path = temp_file.name
+            temp_file.write(formatted_prompt)
+        
+        # Run the persona_dm function with the temporary file
+        result_path = persona_dm(
+            from_file=temp_file_path,
+            models_prefixed_by_provider=decision_maker_models,
+            output_dir=output_directory,
+            output_extension=output_extension,
+            output_path=output_path,
+            persona_dm_model=decision_maker_model,
+            persona_prompt=decision_maker_prompt
+        )
+        
+        # Clean up the temporary file
+        os.unlink(temp_file_path)
+        
+        return result_path
+        
+    except Exception as e:
+        # Handle errors with the decision maker process
+        error_message = f"Error in decision maker process for {persona_name}: {str(e)}"
+        
+        # Determine error file path
+        if output_path:
+            # Create error file next to the specified output path
+            dir_path = os.path.dirname(output_path) or "."
+            base_name = os.path.basename(output_path)
+            name, ext = os.path.splitext(base_name)
+            error_file_path = os.path.join(dir_path, f"{name}_error{ext}")
+        else:
+            # Create standard error file in the output directory
+            base_filename = os.path.basename(from_file)
+            file_name, _ = os.path.splitext(base_filename)
+            extension = ".md"
+            if output_extension:
+                extension = output_extension if output_extension.startswith(".") else f".{output_extension}"
+            error_file_path = os.path.join(output_directory, f"{file_name}_{persona_name}_decision_making_error{extension}")
+        
+        # Ensure parent directory exists
+        os.makedirs(os.path.dirname(error_file_path) or ".", exist_ok=True)
+        
+        # Write error to file
+        write_file(error_file_path, error_message)
+        
+        # Try to clean up the temporary file if it still exists
+        try:
+            if 'temp_file_path' in locals() and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+        except:
+            pass
+            
+        raise ToolError(error_message)

--- a/src/agile_team/tools/persona_base.py
+++ b/src/agile_team/tools/persona_base.py
@@ -16,12 +16,12 @@ def persona_base(
     persona_name: str,
     persona_prompt: str,
     from_file: str,
-    models_prefixed_by_provider: List[str] = None,
-    output_dir: str = None,
-    output_extension: str = None,
-    output_path: str = None,
+    models_prefixed_by_provider: Optional[List[str]] = None,
+    output_dir: Optional[str] = None,
+    output_extension: Optional[str] = None,
+    output_path: Optional[str] = None,
     use_decision_maker: bool = False,
-    decision_maker_models: List[str] = None,
+    decision_maker_models: Optional[List[str]] = None,
     decision_maker_model: str = DEFAULT_DECISION_MAKER_MODEL,
     decision_maker_prompt: str = DEFAULT_PERSONA_PROMPT
 ) -> str:


### PR DESCRIPTION
## Summary
- Add a specialized Business Analyst persona tool that can generate detailed business analysis from requirements
- Support both single-model and team-based decision making approaches for business analysis
- Include specialized prompt templates for business requirements analysis

## Test plan
- Run unit tests for persona_ba and persona_base functionality
- Test with various input files and model configurations
- Verify output format and quality of business analysis

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)